### PR TITLE
use stable version of jms serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,11 @@
   "license": "LGPL",
   "require": {
     "php": ">=5.5",
-    "jms/serializer": "serializer-master-dev as 1.0"
+    "jms/serializer": "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0"
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/goetas/serializer.git"
-    }
-  ],
   "autoload": {
     "psr-4": {
       "GoetasWebservices\\Xsd\\XsdToPhpRuntime\\": "src/"


### PR DESCRIPTION
My main motivation here is to make it possible for authorizenet/authorizenet to use a stable version of jms serializer.

The stable version is over a hundred commits ahead of your fork so hopefully whatever issue you were working around has been resolved.