### PR TITLE
Removed timezone trim as some systems may require it although it's optional

### DIFF
--- a/src/Jms/Handler/XmlSchemaDateHandler.php
+++ b/src/Jms/Handler/XmlSchemaDateHandler.php
@@ -67,9 +67,7 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
     {
 
         $v = $date->format(\DateTime::W3C);
-        if (substr($v, -5) == "00:00") {
-            $v = substr($v, 0, -6);
-        }
+
         return $visitor->visitSimpleString($v, $type, $context);
     }
 

--- a/tests/XmlSchemaDateHandlerSerializationTest.php
+++ b/tests/XmlSchemaDateHandlerSerializationTest.php
@@ -62,6 +62,7 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+20:00'), '2015-01-01T12:00:56+20:00'],
+            [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/Rome")), '2015-01-01T12:00:56+01:00'],
         ];

--- a/tests/XmlSchemaDateHandlerSerializationTest.php
+++ b/tests/XmlSchemaDateHandlerSerializationTest.php
@@ -63,7 +63,7 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+20:00'), '2015-01-01T12:00:56+20:00'],
             [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
-            [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/Rome")), '2015-01-01T12:00:56+01:00'],
+            [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/Rome")), '2015-01-01T12:00:56+01:00'],
         ];
     }
 }

--- a/tests/XmlSchemaDateHandlerSerializationTest.php
+++ b/tests/XmlSchemaDateHandlerSerializationTest.php
@@ -58,11 +58,11 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
     public function getSerializeDateTime()
     {
         return [
-            [new \DateTime('2015-01-01 12:00'), '2015-01-01T12:00:00'],
-            [new \DateTime('2015-01-01 12:00:56'), '2015-01-01T12:00:56'],
-            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56'],
+            [new \DateTime('2015-01-01 12:00+00:00'), '2015-01-01T12:00:00+00:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+20:00'), '2015-01-01T12:00:56+20:00'],
-            [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56'],
+            [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
         ];
     }
 }

--- a/tests/XmlSchemaDateHandlerSerializationTest.php
+++ b/tests/XmlSchemaDateHandlerSerializationTest.php
@@ -63,6 +63,7 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+20:00'), '2015-01-01T12:00:56+20:00'],
             [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/Rome")), '2015-01-01T12:00:56+01:00'],
         ];
     }
 }


### PR DESCRIPTION
Related to: https://github.com/goetas-webservices/xsd2php-runtime/issues/4