### PR TITLE
Add serialize and deserialize timezone shifting support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "jms/serializer": "1.4.1|1.6.1|1.6.2"
   },  
   "require-dev": {
+    "ext-simplexml": "*",
     "phpunit/phpunit": "^4.8|^5.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "goetas-webservices/xsd2php-runtime",
+  "name": "lucasthecure/xsd2php-runtime",
   "description": "Convert XSD  (XML Schema) definitions into PHP classes",
   "type": "library",
   "authors": [
@@ -42,5 +42,8 @@
     "branch-alias": {
       "dev-master": "0.2-dev"
     }
+  },
+  "replace": {
+    "goetas-webservices/xsd2php-runtime": "self.version"
   }
 }

--- a/tests/XmlSchemaDateHandlerDeserializationTest.php
+++ b/tests/XmlSchemaDateHandlerDeserializationTest.php
@@ -12,7 +12,6 @@ use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Metadata\Driver\AnnotationDriver;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\XmlDeserializationVisitor;
-use JMS\Serializer\XmlSerializationVisitor;
 use Metadata\MetadataFactory;
 
 class XmlSchemaDateHandlerDeserializationTest extends \PHPUnit_Framework_TestCase
@@ -67,7 +66,7 @@ class XmlSchemaDateHandlerDeserializationTest extends \PHPUnit_Framework_TestCas
 
     /**
      * @dataProvider getDeserializeDate
-     * @param string    $date
+     * @param string $date
      * @param \DateTime $expected
      */
     public function testDeserializeDate($date, \DateTime $expected)
@@ -88,11 +87,151 @@ class XmlSchemaDateHandlerDeserializationTest extends \PHPUnit_Framework_TestCas
     }
 
     /**
+     * @requires PHP 7.0
+     * @dataProvider getDeserializeDateWithTimezone
+     * @param string $date
+     * @param \DateTime $expected
+     * @param string $defaultTimezone
+     * @param string $serializeTimezone
+     * @param string $deserializeTimezone
+     */
+    public function testDeserializeDateWithTimezone(
+        $date,
+        \DateTime $expected,
+        $defaultTimezone = 'UTC',
+        $serializeTimezone = null,
+        $deserializeTimezone = null
+    ) {
+        $handler = new XmlSchemaDateHandler($defaultTimezone, $serializeTimezone, $deserializeTimezone);
+        $element = new \SimpleXMLElement("<Date>$date</Date>");
+        $deserialized = $handler->deserializeDate($this->visitor, $element, [], $this->context);
+        $this->assertEquals($expected, $deserialized);
+    }
+
+    public function getDeserializeDateWithTimezone()
+    {
+        $tzPlus6 = new \DateTimeZone('+06:00');
+        $tzMinus20 = new \DateTimeZone('-20:00');
+
+        return [
+            // timezone is not set (default timezone is used)
+            ['2015-01-01', new \DateTime('2015-01-01'), 'UTC'],
+            ['2015-01-01', new \DateTime('2015-01-01', $tzPlus6), '+06:00'],
+            ['2015-01-01', new \DateTime('2015-01-01', $tzMinus20), '-20:00'],
+            // timezone is set (note that default timezone is ignored by php DateTime constructor)
+            ['2015-01-01Z', new \DateTime('2015-01-01+00:00'), 'UTC'],
+            ['2015-01-01Z', new \DateTime('2015-01-01+00:00'), '+06:00'],
+            ['2015-01-01+06:00', new \DateTime('2015-01-01+06:00'), 'UTC'],
+            ['2015-01-01+06:00', new \DateTime('2015-01-01+06:00'), '-20:00'],
+            // deserialize timezone is set (here we expect timezone shifting to required one)
+            ['2015-01-01Z', new \DateTime('2015-01-01+00:00'), 'UTC', null, 'UTC'],
+            ['2015-01-01Z', new \DateTime('2015-01-01 06:00:00+06:00'), 'UTC', null, '+06:00'],
+            ['2015-01-01Z', new \DateTime('2014-12-31 04:00:00-20:00'), 'UTC', null, '-20:00'],
+            ['2015-01-01+06:00', new \DateTime('2015-01-01+06:00'), 'UTC', null, '+0:00'],
+            ['2015-01-01+06:00', new \DateTime('2015-01-01 02:00:00+8:00'), 'UTC', null, '+8:00'],
+            ['2015-01-01+06:00', new \DateTime('2014-12-30 22:00:00-20:00'), 'UTC', null, '-20:00'],
+        ];
+    }
+
+    /**
      * @expectedException \RuntimeException
      */
     public function testDeserializeInvalidDate()
     {
         $element = new \SimpleXMLElement("<Date>2015-01-01T</Date>");
         $this->handler->deserializeDate($this->visitor, $element, [], $this->context);
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @dataProvider getDeserializeDateTimeWithTimezone
+     * @param string $date
+     * @param \DateTime $expected
+     * @param string $defaultTimezone
+     * @param string $serializeTimezone
+     * @param string $deserializeTimezone
+     */
+    public function testDeserializeDateTimeWithTimezone(
+        $date,
+        \DateTime $expected,
+        $defaultTimezone = 'UTC',
+        $serializeTimezone = null,
+        $deserializeTimezone = null
+    ) {
+        $handler = new XmlSchemaDateHandler($defaultTimezone, $serializeTimezone, $deserializeTimezone);
+        $element = new \SimpleXMLElement("<Datetime>$date</Datetime>");
+        $deserialized = $handler->deserializeDateTime($this->visitor, $element, [], $this->context);
+        $this->assertEquals($expected, $deserialized);
+    }
+
+    public function getDeserializeDateTimeWithTimezone()
+    {
+        $tzPlus6 = new \DateTimeZone('+06:00');
+        $tzMinus20 = new \DateTimeZone('-20:00');
+
+        return [
+            // timezone is not set (default timezone is used)
+            ['2015-01-01T10:01:01', new \DateTime('2015-01-01 10:01:01'), 'UTC'],
+            ['2015-01-01T10:01:01', new \DateTime('2015-01-01 10:01:01', $tzPlus6), '+06:00'],
+            ['2015-01-01T10:01:01', new \DateTime('2015-01-01 10:01:01', $tzMinus20), '-20:00'],
+            // timezone is set (note that default timezone is ignored by php DateTime constructor)
+            ['2015-01-01T10:01:01Z', new \DateTime('2015-01-01 10:01:01+0:00'), 'UTC'],
+            ['2015-01-01T10:01:01Z', new \DateTime('2015-01-01 10:01:01+0:00'), '+06:00'],
+            ['2015-01-01T10:01:01+06:00', new \DateTime('2015-01-01 10:01:01+06:00'), 'UTC'],
+            ['2015-01-01T10:01:01+06:00', new \DateTime('2015-01-01 10:01:01+6:00'), '-20:00'],
+            // deserialize timezone is set (here we expect timezone shifting to required one)
+            ['2015-01-01T10:01:01Z', new \DateTime('2015-01-01 10:01:01+0:00'), 'UTC', null, 'UTC'],
+            ['2015-01-01T10:01:01Z', new \DateTime('2015-01-01 16:01:01+6:00'), 'UTC', null, '+06:00'],
+            ['2015-01-01T10:01:01Z', new \DateTime('2014-12-31 14:01:01-20:00'), 'UTC', null, '-20:00'],
+            ['2015-01-01T10:01:01+06:00', new \DateTime('2015-01-01 04:01:01+0:00'), 'UTC', null, '+0:00'],
+            ['2015-01-01T10:01:01+06:00', new \DateTime('2015-01-01 12:01:01+8:00'), 'UTC', null, '+8:00'],
+            ['2015-01-01T10:01:01+06:00', new \DateTime('2014-12-31 08:01:01-20:00'), 'UTC', null, '-20:00'],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @dataProvider getDeserializeTimeWithTimezone
+     * @param string $date
+     * @param \DateTime $expected
+     * @param string $defaultTimezone
+     * @param string $serializeTimezone
+     * @param string $deserializeTimezone
+     */
+    public function testDeserializeTimeWithTimezone(
+        $date,
+        \DateTime $expected,
+        $defaultTimezone = 'UTC',
+        $serializeTimezone = null,
+        $deserializeTimezone = null
+    ) {
+        $handler = new XmlSchemaDateHandler($defaultTimezone, $serializeTimezone, $deserializeTimezone);
+        $element = new \SimpleXMLElement("<Time>$date</Time>");
+        $deserialized = $handler->deserializeTime($this->visitor, $element, [], $this->context);
+        $this->assertEquals($expected, $deserialized);
+    }
+
+    public function getDeserializeTimeWithTimezone()
+    {
+        $tzPlus6 = new \DateTimeZone('+06:00');
+        $tzMinus12 = new \DateTimeZone('-12:00');
+
+        return [
+            // timezone is not set (default timezone is used)
+            ['10:01:01', new \DateTime('10:01:01'), 'UTC'],
+            ['10:01:01', new \DateTime('10:01:01', $tzPlus6), '+06:00'],
+            ['10:01:01', new \DateTime('10:01:01', $tzMinus12), '-12:00'],
+            // timezone is set (note that default timezone is ignored by php DateTime constructor)
+            ['10:01:01Z', new \DateTime('10:01:01+0:00'), 'UTC'],
+            ['10:01:01+06:00', new \DateTime('10:01:01+06:00'), 'UTC'],
+            ['10:01:01-12:00', new \DateTime('10:01:01-12:00'), 'UTC'],
+            // deserialize timezone is set (here we expect timezone shifting to required one)
+            ['10:01:01Z', new \DateTime('10:01:01+00:00'), 'UTC', null, 'UTC'],
+            ['10:01:01Z', new \DateTime('16:01:01+06:00'), 'UTC', null, '+06:00'],
+            ['10:01:01Z', new \DateTime('02:01:01-08:00'), 'UTC', null, '-8:00'],
+            ['10:01:01+06:00', new \DateTime('04:01:01+0:00'), 'UTC', null, '+0:00'],
+            ['10:01:01+00:00', new \DateTime('18:01:01+8:00'), 'UTC', null, '+8:00'],
+            ['10:01:01+08:00', new \DateTime('00:01:01-2:00'), 'UTC', null, '-2:00'],
+        ];
     }
 }

--- a/tests/XmlSchemaDateHandlerSerializationTest.php
+++ b/tests/XmlSchemaDateHandlerSerializationTest.php
@@ -66,6 +66,7 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getSerializeDateTime
      * @param \DateTime $date
+     * @param string $expected
      */
     public function testSerializeDateTime(\DateTime $date, $expected)
     {
@@ -84,6 +85,43 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56+00:00', new \DateTimeZone("Europe/London")), '2015-01-01T12:00:56+00:00'],
             [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/Rome")), '2015-01-01T12:00:56+01:00'],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @dataProvider getSerializeDateTimeWithTimezone
+     * @param \DateTime $date
+     * @param string $expected
+     * @param string $defaultTimezone
+     * @param string $serializeTimezone
+     * @param string $deserializeTimezone
+     */
+    public function testSerializeDateTimeWithTimezone(
+        \DateTime $date,
+        $expected,
+        $defaultTimezone = 'UTC',
+        $serializeTimezone = null,
+        $deserializeTimezone = null
+    ) {
+        $handler = new XmlSchemaDateHandler($defaultTimezone, $serializeTimezone, $deserializeTimezone);
+        $ret = $handler->serializeDateTime($this->visitor, $date, [], $this->context);
+        $actual = $ret ? $ret->nodeValue : $this->visitor->getCurrentNode()->nodeValue;
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function getSerializeDateTimeWithTimezone()
+    {
+        return [
+            // serialize timezone is set (here we expect timezone shifting to required one)
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T12:00:56+00:00', 'UTC', 'Z'],
+            [new \DateTime('2015-01-01 12:00:56+02:00'), '2015-01-01T10:00:56+00:00', 'UTC', 'Z'],
+            [new \DateTime('2015-01-01 12:00:56+06:00'), '2015-01-01T06:00:56+00:00', 'UTC', '+00:00'],
+            [new \DateTime('2015-01-01 12:00:56+06:00'), '2015-01-01T12:00:56+06:00', 'UTC', '+06:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T18:00:56+06:00', 'UTC', '+06:00'],
+            [new \DateTime('2015-01-01 12:00:56+12:00'), '2015-01-01T06:00:56+06:00', 'UTC', '+06:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01T06:00:56-06:00', 'UTC', '-06:00'],
+            [new \DateTime('2015-01-01 12:00:56-12:00'), '2015-01-01T18:00:56-06:00', 'UTC', '-06:00'],
         ];
     }
 
@@ -108,6 +146,42 @@ class XmlSchemaDateHandlerSerializationTest extends \PHPUnit_Framework_TestCase
             [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01'],
             [new \DateTime('2015-01-01 12:00:56+20:00'), '2015-01-01'],
             [new \DateTime('2015-01-01 12:00:56', new \DateTimeZone("Europe/London")), '2015-01-01'],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @dataProvider getSerializeDateWithTimezone
+     * @param \DateTime $date
+     * @param string $expected
+     * @param string $defaultTimezone
+     * @param string $serializeTimezone
+     * @param string $deserializeTimezone
+     */
+    public function testSerializeDateWithTimezone(
+        \DateTime $date,
+        $expected,
+        $defaultTimezone = 'UTC',
+        $serializeTimezone = null,
+        $deserializeTimezone = null
+    ) {
+        $handler = new XmlSchemaDateHandler($defaultTimezone, $serializeTimezone, $deserializeTimezone);
+        $ret = $handler->serializeDate($this->visitor, $date, [], $this->context);
+        $actual = $ret ? $ret->nodeValue : $this->visitor->getCurrentNode()->nodeValue;
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function getSerializeDateWithTimezone()
+    {
+        return [
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01', 'UTC', 'Z'],
+            [new \DateTime('2015-01-01 12:00:56+02:00'), '2015-01-01', 'UTC', 'Z'],
+            [new \DateTime('2015-01-01 12:00:56-02:00'), '2015-01-01', 'UTC', 'Z'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-01', 'UTC', '+06:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-02', 'UTC', '+12:00'],
+            [new \DateTime('2015-01-01 11:00:50+00:00'), '2014-12-31', 'UTC', '-12:00'],
+            [new \DateTime('2015-01-01 12:00:56+06:00'), '2015-01-01', 'UTC', '+06:00'],
+            [new \DateTime('2015-01-01 12:00:56+00:00'), '2015-01-02', 'UTC', '+25:00'],
         ];
     }
 }


### PR DESCRIPTION
Allows to set destination timezone during serialization and deserialization.
Already provided defaultTimezone is used during deserialization only if timezone is absent in serialized string. This PR allows to force timezone to required one. 

Some differences are between date comparison between php 5.6 and 7.0. That is why new functionality is limited to version 7.0 and above