### PR TITLE
added fix for DateInterval and microseconds

### DIFF
--- a/src/Jms/Handler/XmlSchemaDateHandler.php
+++ b/src/Jms/Handler/XmlSchemaDateHandler.php
@@ -72,7 +72,7 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
         if (isset($attributes['nil'][0]) && (string) $attributes['nil'][0] === 'true') {
             return null;
         }
-        return new \DateInterval((string)$data);
+        return $this->createDateInterval((string)$data);
     }
 
     public function serializeDate(XmlSerializationVisitor $visitor, \DateTime $date, array $type, Context $context)
@@ -145,6 +145,21 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
         }
 
         return $datetime;
+    }
+
+    private function createDateInterval(string $interval){
+        $f = 0.0;
+        if(preg_match('~\.\d+~',$interval,$match)){
+            $interval = str_replace($match[0], "", $interval);
+            $f = (float)$match[0];
+        }
+        $di = new \DateInterval($interval);
+        // milliseconds are only available from >=7.1
+        if(isset($di->f)){
+            $di->f= $f;
+        }
+
+        return $di;
     }
 }
 

--- a/src/Jms/Handler/XmlSchemaDateHandler.php
+++ b/src/Jms/Handler/XmlSchemaDateHandler.php
@@ -147,9 +147,9 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
         return $datetime;
     }
 
-    private function createDateInterval(string $interval){
+    private function createDateInterval($interval){
         $f = 0.0;
-        if(preg_match('~\.\d+~',$interval,$match)){
+        if (preg_match('~\.\d+~',$interval,$match)) {
             $interval = str_replace($match[0], "", $interval);
             $f = (float)$match[0];
         }

--- a/tests/XmlSchemaDateHandlerDeserializationTest.php
+++ b/tests/XmlSchemaDateHandlerDeserializationTest.php
@@ -86,14 +86,17 @@ class XmlSchemaDateHandlerDeserializationTest extends \PHPUnit_Framework_TestCas
     {
         $element = new \SimpleXMLElement("<DateInterval>$dateInterval</DateInterval>");
         $deserialized = $this->handler->deserializeDateIntervalXml($this->visitor, $element, [], $this->context);
-        $this->assertEquals($expected, $deserialized->f);
+        if (isset($deserialized->f)) {
+            $this->assertEquals($expected['f'], $deserialized->f);
+        }
+        $this->assertEquals($expected['s'], $deserialized->s);
     }
 
     public function getDeserializeDateInterval()
     {
         return [
-            ['P0Y0M0DT3H5M7.520S', 0.52],
-            ['P0Y0M0DT3H5M7S', 0]
+            ['P0Y0M0DT3H5M7.520S', ['s' => 7, 'f' => 0.52]],
+            ['P0Y0M0DT3H5M7S', ['s' => 7, 'f' => 0]]
         ];
     }
 

--- a/tests/XmlSchemaDateHandlerDeserializationTest.php
+++ b/tests/XmlSchemaDateHandlerDeserializationTest.php
@@ -77,6 +77,26 @@ class XmlSchemaDateHandlerDeserializationTest extends \PHPUnit_Framework_TestCas
         $this->assertEquals($expected, $deserialized);
     }
 
+    /**
+     * @dataProvider getDeserializeDateInterval
+     * @param string    $dateInterval
+     * @param \DateTime $expected
+     */
+    public function testDeserializeDateInterval($dateInterval, $expected)
+    {
+        $element = new \SimpleXMLElement("<DateInterval>$dateInterval</DateInterval>");
+        $deserialized = $this->handler->deserializeDateIntervalXml($this->visitor, $element, [], $this->context);
+        $this->assertEquals($expected, $deserialized->f);
+    }
+
+    public function getDeserializeDateInterval()
+    {
+        return [
+            ['P0Y0M0DT3H5M7.520S', 0.52],
+            ['P0Y0M0DT3H5M7S', 0]
+        ];
+    }
+
     public function getDeserializeDate()
     {
         return [


### PR DESCRIPTION
There is a bug in PHP for DateInterval construction and microseconds: https://bugs.php.net/bug.php?id=53831

This fixes the creation of DateInterval with microseconds like: P0Y0M0DT3H5M7.520S
Context: https://stackoverflow.com/questions/60435670/dateinterval-doesnt-accept-iso-8601-timeperiod-with-milliseconds