### PR TITLE
Added PHP 8.0 to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0  
 
 matrix:
   include:


### PR DESCRIPTION
Not sure why the package wasn't tested on Travis against PHP 8.0 before, but the library claims to be compatible with PHP 8.0 since https://github.com/goetas-webservices/xsd2php-runtime/commit/a828d6ec8365bb45adcd6e4207eaf2f0789544b9.

I hope the green build would help to publish the next patch release compatible with PHP 8.0 earlier🤞.

Thank you very much for the great project!