### PR TITLE
fix symfony deprecations

### DIFF
--- a/src/Jms/Handler/BaseTypesHandler.php
+++ b/src/Jms/Handler/BaseTypesHandler.php
@@ -10,6 +10,9 @@ use JMS\Serializer\XmlSerializationVisitor;
 class BaseTypesHandler implements SubscribingHandlerInterface
 {
 
+    /**
+     * @return array
+     */
     public static function getSubscribingMethods()
     {
         return array(

--- a/src/Jms/Handler/XmlSchemaDateHandler.php
+++ b/src/Jms/Handler/XmlSchemaDateHandler.php
@@ -13,6 +13,9 @@ class XmlSchemaDateHandler implements SubscribingHandlerInterface
 
     protected $defaultTimezone;
 
+    /**
+     * @return array
+     */
     public static function getSubscribingMethods()
     {
         return array(


### PR DESCRIPTION
Fixes symfony warnings like:

Method "JMS\Serializer\Handler\SubscribingHandlerInterface::getSubscribingMethods()" might add "array" as a native return type declaration in the future. Do the same in implementation "GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\XmlSchemaDateHandler" now to avoid errors or add an explicit @return annotation to suppress this message.